### PR TITLE
Include FFTW with MPI support

### DIFF
--- a/.ci_support/linux_64_mpimpich.yaml
+++ b/.ci_support/linux_64_mpimpich.yaml
@@ -16,8 +16,6 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
-fftw:
-- '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:

--- a/.ci_support/linux_64_mpiopenmpi.yaml
+++ b/.ci_support/linux_64_mpiopenmpi.yaml
@@ -16,8 +16,6 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
-fftw:
-- '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:

--- a/.ci_support/linux_aarch64_mpimpich.yaml
+++ b/.ci_support/linux_aarch64_mpimpich.yaml
@@ -16,8 +16,6 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
-fftw:
-- '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:

--- a/.ci_support/linux_aarch64_mpiopenmpi.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpi.yaml
@@ -16,8 +16,6 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
-fftw:
-- '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:

--- a/.ci_support/linux_ppc64le_mpimpich.yaml
+++ b/.ci_support/linux_ppc64le_mpimpich.yaml
@@ -16,8 +16,6 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
-fftw:
-- '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:

--- a/.ci_support/linux_ppc64le_mpiopenmpi.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpi.yaml
@@ -16,8 +16,6 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
-fftw:
-- '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:

--- a/.ci_support/osx_64_mpimpich.yaml
+++ b/.ci_support/osx_64_mpimpich.yaml
@@ -18,8 +18,6 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '19'
-fftw:
-- '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:

--- a/.ci_support/osx_64_mpiopenmpi.yaml
+++ b/.ci_support/osx_64_mpiopenmpi.yaml
@@ -18,8 +18,6 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '19'
-fftw:
-- '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:

--- a/.ci_support/osx_arm64_mpimpich.yaml
+++ b/.ci_support/osx_arm64_mpimpich.yaml
@@ -18,8 +18,6 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '19'
-fftw:
-- '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:

--- a/.ci_support/osx_arm64_mpiopenmpi.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpi.yaml
@@ -18,8 +18,6 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '19'
-fftw:
-- '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,3 @@
 mpi:
-  - openmpi
   - mpich
+  - openmpi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "spfft" %}
 {% set version = "1.1.1" %}
 
-{% set build = 1 %}
+{% set build = 2 %}
 
 {% set mpi = mpi or "openmpi" %}
 {% set mpi_prefix = "mpi_" + mpi %}
@@ -24,7 +24,7 @@ outputs:
     build:
       string: {{ mpi_prefix }}_h{{ PKG_HASH }}_{{ build }}
       run_exports:
-        - {{ pin_subpackage("spfft", max_pin="x") }}
+        - {{ pin_subpackage("spfft", max_pin="x.x") }}
     requirements:
       build:
         - {{ compiler("c") }}
@@ -33,14 +33,16 @@ outputs:
         - {{ compiler("fortran") }}
         - {{ mpi }}
         - cmake >=3.18
-        - ninja
+        - ninja >=1.13
         - pkg-config
       host:
         - {{ mpi }}
-        - fftw
+        - _openmp_mutex
+        - "fftw * {{ mpi_prefix }}_*"
       run:
         - {{ mpi }}
-        - fftw
+        - _openmp_mutex
+        - "fftw * {{ mpi_prefix }}_*"
     test:
       commands:
         - test -f "${PREFIX}/lib/libspfft${SHLIB_EXT}"
@@ -50,8 +52,6 @@ outputs:
     script: build-spfft.sh
     build:
       string: {{ mpi_prefix }}_h{{ PKG_HASH }}_{{ build }}
-      run_exports:
-        - {{ pin_subpackage("spfft-static", max_pin="x") }}
     requirements:
       build:
         - {{ compiler("c") }}
@@ -60,14 +60,16 @@ outputs:
         - {{ compiler("fortran") }}
         - {{ mpi }}
         - cmake >=3.18
-        - ninja
+        - ninja >=1.13
         - pkg-config
       host:
         - {{ mpi }}
-        - fftw
+        - _openmp_mutex
+        - "fftw * {{ mpi_prefix }}_*"
       run:
         - {{ mpi }}
-        - fftw
+        - _openmp_mutex
+        - "fftw * {{ mpi_prefix }}_*"
     test:
       commands:
         - test -f "${PREFIX}/lib/libspfft.a"


### PR DESCRIPTION
- MNT: Re-rendered with conda-smithy 3.61.2 and conda-forge-pinning 2026.05.14.16.56.12
- Drop run_exports section for static variant

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
